### PR TITLE
feat: Store Token and User Info List

### DIFF
--- a/contracts/ContractInfoStore.sol
+++ b/contracts/ContractInfoStore.sol
@@ -10,6 +10,11 @@ struct GovernanceTokenInfo {
     address[] airdropTargetAddressList;
 }
 
+struct MatchedGovAirdropTokenDTO {
+    address airdropTokenAddress;
+    address governanceTokenAddress;
+}
+
 contract ContractInfoStore {
     event NewGovernanceTokenStored(address governanceTokenAddr, string message);
     GovernanceTokenInfo[] GovernanceTokenList;
@@ -46,5 +51,33 @@ contract ContractInfoStore {
         GovernanceTokenList[foundGovTokenId].airdropTokenAddress = airdropTokenAddr;
         GovernanceTokenList[foundGovTokenId].airdropTargetAddressList = _airdropTargetAddresses;
         return true;
+    }
+
+    function findAirdropTokenAddressListByUserAddr(address userTokenAddr) public view returns (MatchedGovAirdropTokenDTO[] memory) {
+        GovernanceTokenInfo[] memory governanceTokenInfoList = getAllGovernanceTokenInfo();
+        uint allTokenAmounts = governanceTokenInfoList.length;
+
+        MatchedGovAirdropTokenDTO[] memory matchedGovAirdropTokenDTOList = new MatchedGovAirdropTokenDTO[](allTokenAmounts);
+        address[] memory matchedAirdropTokenAddressList = new address[](allTokenAmounts);
+        address[] memory matchedGovernanceTokenAddressList = new address[](allTokenAmounts);
+
+        for (uint i = 0; i < governanceTokenInfoList.length; i++) {
+            GovernanceTokenInfo memory nowGovernanceTokenInfo = governanceTokenInfoList[i];
+            address[] memory nowAirdropAddressList = nowGovernanceTokenInfo.airdropTargetAddressList;
+            for (uint j = 0; j < nowAirdropAddressList.length; j++) {
+                if (nowAirdropAddressList[j] == userTokenAddr) {
+                    matchedAirdropTokenAddressList[i] = nowGovernanceTokenInfo.airdropTokenAddress;
+                    matchedGovernanceTokenAddressList[i] = nowGovernanceTokenInfo.tokenInfo.tokenContractAddress;
+                    console.log("matchedAirdropTokenAddressList", matchedAirdropTokenAddressList[i]);
+                    break;
+                }
+            }
+        }
+
+        for (uint k = 0; k < matchedAirdropTokenAddressList.length; k++) {
+            matchedGovAirdropTokenDTOList[k] = MatchedGovAirdropTokenDTO(matchedAirdropTokenAddressList[k], matchedGovernanceTokenAddressList[k]);
+        }
+
+        return matchedGovAirdropTokenDTOList;
     }
 }

--- a/contracts/ContractInfoStore.sol
+++ b/contracts/ContractInfoStore.sol
@@ -22,4 +22,8 @@ contract ContractInfoStore {
         // 3. return true
         return true;
     }
+
+    function getAllGovernanceTokenInfo() public view returns (GovernanceTokenInfo[] memory) {
+        return GovernanceTokenList;
+    }
 }

--- a/contracts/ContractInfoStore.sol
+++ b/contracts/ContractInfoStore.sol
@@ -1,6 +1,7 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 import {CommonStructs} from "./CommonStructs.sol";
+import "hardhat/console.sol";
 
 struct GovernanceTokenInfo {
     bool isAirdropContractOpened;
@@ -26,5 +27,22 @@ contract ContractInfoStore {
 
     function getAllGovernanceTokenInfo() public view returns (GovernanceTokenInfo[] memory) {
         return GovernanceTokenList;
+    }
+
+    function findGovernanceTokenListIdByAddr(address governanceTokenAddr) public view returns (uint){
+        for (uint i = 0; i < GovernanceTokenList.length; i++) {
+            if (GovernanceTokenList[i].tokenInfo.tokenContractAddress == governanceTokenAddr) {
+                console.log(" FOUND TOKEN ADDR >>>>>>>>>>>>>>>>>>>>>> ", GovernanceTokenList[i].tokenInfo.tokenContractAddress);
+                return i;
+            }
+        }
+        revert("Not Found Governance Token");
+    }
+
+    function addAirdropTokenAddress(address governanceTokenAddr, address airdropTokenAddr) public returns (bool) {
+        uint foundGovTokenId = findGovernanceTokenListIdByAddr(governanceTokenAddr);
+        GovernanceTokenList[foundGovTokenId].isAirdropContractOpened = true;
+        GovernanceTokenList[foundGovTokenId].airdropTokenAddress = airdropTokenAddr;
+        return true;
     }
 }

--- a/contracts/ContractInfoStore.sol
+++ b/contracts/ContractInfoStore.sol
@@ -7,6 +7,7 @@ struct GovernanceTokenInfo {
     bool isAirdropContractOpened;
     address airdropTokenAddress;
     CommonStructs.TokenInfo tokenInfo;
+    address[] airdropTargetAddressList;
 }
 
 contract ContractInfoStore {
@@ -15,7 +16,7 @@ contract ContractInfoStore {
 
     function storeNewGovernanceToken(CommonStructs.TokenInfo memory _tokenInfo) public returns (bool) {
         // 1. creating the GovernanceTokenInfo Struct
-        GovernanceTokenInfo memory governanceTokenInfo = GovernanceTokenInfo(false, 0x0000000000000000000000000000000000000000, _tokenInfo);
+        GovernanceTokenInfo memory governanceTokenInfo = GovernanceTokenInfo(false, 0x0000000000000000000000000000000000000000, _tokenInfo, new address[](0));
 
         // 2. push to the list
         GovernanceTokenList.push(governanceTokenInfo);
@@ -39,10 +40,11 @@ contract ContractInfoStore {
         revert("Not Found Governance Token");
     }
 
-    function addAirdropTokenAddress(address governanceTokenAddr, address airdropTokenAddr) public returns (bool) {
+    function addAirdropTokenAddress(address governanceTokenAddr, address airdropTokenAddr, address[] calldata _airdropTargetAddresses) public returns (bool) {
         uint foundGovTokenId = findGovernanceTokenListIdByAddr(governanceTokenAddr);
         GovernanceTokenList[foundGovTokenId].isAirdropContractOpened = true;
         GovernanceTokenList[foundGovTokenId].airdropTokenAddress = airdropTokenAddr;
+        GovernanceTokenList[foundGovTokenId].airdropTargetAddressList = _airdropTargetAddresses;
         return true;
     }
 }

--- a/contracts/ContractInfoStore.sol
+++ b/contracts/ContractInfoStore.sol
@@ -1,0 +1,25 @@
+pragma solidity >=0.7.0 <0.9.0;
+
+import {CommonStructs} from "./CommonStructs.sol";
+
+struct GovernanceTokenInfo {
+    bool isAirdropContractOpened;
+    CommonStructs.TokenInfo tokenInfo;
+}
+
+contract ContractInfoStore {
+    event NewGovernanceTokenStored(address governanceTokenAddr, string message);
+    GovernanceTokenInfo[] GovernanceTokenList;
+
+    function storeNewGovernanceToken(CommonStructs.TokenInfo memory _tokenInfo) public returns (bool) {
+        // 1. creating the GovernanceTokenInfo Struct
+        GovernanceTokenInfo memory governanceTokenInfo = GovernanceTokenInfo(false, _tokenInfo);
+
+        // 2. push to the list
+        GovernanceTokenList.push(governanceTokenInfo);
+        emit NewGovernanceTokenStored(_tokenInfo.tokenContractAddress, "New Governance Token was created");
+
+        // 3. return true
+        return true;
+    }
+}

--- a/contracts/ContractInfoStore.sol
+++ b/contracts/ContractInfoStore.sol
@@ -4,6 +4,7 @@ import {CommonStructs} from "./CommonStructs.sol";
 
 struct GovernanceTokenInfo {
     bool isAirdropContractOpened;
+    address airdropTokenAddress;
     CommonStructs.TokenInfo tokenInfo;
 }
 
@@ -13,7 +14,7 @@ contract ContractInfoStore {
 
     function storeNewGovernanceToken(CommonStructs.TokenInfo memory _tokenInfo) public returns (bool) {
         // 1. creating the GovernanceTokenInfo Struct
-        GovernanceTokenInfo memory governanceTokenInfo = GovernanceTokenInfo(false, _tokenInfo);
+        GovernanceTokenInfo memory governanceTokenInfo = GovernanceTokenInfo(false, 0x0000000000000000000000000000000000000000, _tokenInfo);
 
         // 2. push to the list
         GovernanceTokenList.push(governanceTokenInfo);

--- a/contracts/DAOForceToken.sol
+++ b/contracts/DAOForceToken.sol
@@ -26,8 +26,11 @@ contract DAOForceToken is ERC20Trackable {
             _intro,
             _image,
             _link,
+            _initial_supply,
             _owner,
-            contractInfoStoreAddr) {
+            address(this),
+            contractInfoStoreAddr
+    ) {
         _mint(address(this), _initial_supply * 10 ** uint(decimals()));
     }
 }

--- a/contracts/DAOForceToken.sol
+++ b/contracts/DAOForceToken.sol
@@ -17,16 +17,17 @@ contract DAOForceToken is ERC20Trackable {
         string memory _image,
         string memory _link,
         address _owner,
-        uint256 _initial_supply
+        uint256 _initial_supply,
+        address contractInfoStoreAddr
     )  ERC20Trackable (
-        _name,
-        _symbol,
-        _DAOName,
-        _intro,
-        _image,
-        _link,
-        _owner)
-    {
+            _name,
+            _symbol,
+            _DAOName,
+            _intro,
+            _image,
+            _link,
+            _owner,
+            contractInfoStoreAddr) {
         _mint(address(this), _initial_supply * 10 ** uint(decimals()));
     }
 }

--- a/contracts/ERC20Trackable.sol
+++ b/contracts/ERC20Trackable.sol
@@ -9,9 +9,12 @@ import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "hardhat/console.sol";
 
 import {CommonStructs} from "./CommonStructs.sol";
+import "./ContractInfoStore.sol";
 
 
-contract ERC20Trackable is ERC20, ERC20Permit, ERC20Votes { 
+contract ERC20Trackable is ERC20, ERC20Permit, ERC20Votes {
+
+    ContractInfoStore contractInfoStore;
 
     // round index marker for the last executed Airdrop batch round.
     uint16 private roundNumber = 1;  // TODO: Initialize to Zero?
@@ -29,13 +32,15 @@ contract ERC20Trackable is ERC20, ERC20Permit, ERC20Votes {
         string memory intro,
         string memory image,
         string memory link,
-        address owner
+        address owner,
+        address contractInfoStoreAddr
     ) ERC20 (_name, _symbol) ERC20Permit(_name) {
         _DAOName = DAOName;
         _intro = intro;
         _image = image;
         _link = link;
         _owner = owner;
+        contractInfoStore = ContractInfoStore(contractInfoStoreAddr);
     }
 
     function getDAOName() public view returns (string memory) {

--- a/contracts/ERC20Trackable.sol
+++ b/contracts/ERC20Trackable.sol
@@ -32,7 +32,9 @@ contract ERC20Trackable is ERC20, ERC20Permit, ERC20Votes {
         string memory intro,
         string memory image,
         string memory link,
+        uint256 _initial_supply,
         address owner,
+        address mintedERC20ContractAddr,
         address contractInfoStoreAddr
     ) ERC20 (_name, _symbol) ERC20Permit(_name) {
         _DAOName = DAOName;
@@ -40,7 +42,20 @@ contract ERC20Trackable is ERC20, ERC20Permit, ERC20Votes {
         _image = image;
         _link = link;
         _owner = owner;
+
+        CommonStructs.TokenInfo memory _tokenInfo = CommonStructs.TokenInfo(
+            _initial_supply * 10 ** uint(decimals()),
+            _name,
+            _symbol,
+            DAOName,
+            intro,
+            image,
+            link,
+            owner,
+            mintedERC20ContractAddr
+        );
         contractInfoStore = ContractInfoStore(contractInfoStoreAddr);
+        contractInfoStore.storeNewGovernanceToken(_tokenInfo);
     }
 
     function getDAOName() public view returns (string memory) {

--- a/contracts/ScheduledAirdrop.sol
+++ b/contracts/ScheduledAirdrop.sol
@@ -15,6 +15,8 @@ pragma solidity ^0.8.0;
 
 contract ScheduledAirDrop {
 
+    ContractInfoStore public contractInfoStore;
+
     address public tokenAddress;
 
     uint32 public numOfTotalRounds;
@@ -53,8 +55,11 @@ contract ScheduledAirDrop {
         uint32 _numOfTotalRounds,
         address[] memory _airdropTargetAddresses,
         uint256[] memory _airdropAmountsPerRoundByAddress,
-        uint256 _totalAirdropVolumePerRound
+        uint256 _totalAirdropVolumePerRound,
+        address ContractInfoStoreAddr
     ){
+        contractInfoStore = ContractInfoStore(ContractInfoStoreAddr);
+        contractInfoStore.addAirdropTokenAddress(_tokenAddress, address(this));
         token = DAOForceToken(_tokenAddress);  // Check: how to verify the pre-deployed contract address is correct?
         // token = ERC20Trackable(_tokenAddress);
         tokenAddress = _tokenAddress;

--- a/contracts/ScheduledAirdrop.sol
+++ b/contracts/ScheduledAirdrop.sol
@@ -59,7 +59,6 @@ contract ScheduledAirDrop {
         address ContractInfoStoreAddr
     ){
         contractInfoStore = ContractInfoStore(ContractInfoStoreAddr);
-        contractInfoStore.addAirdropTokenAddress(_tokenAddress, address(this));
         token = DAOForceToken(_tokenAddress);  // Check: how to verify the pre-deployed contract address is correct?
         // token = ERC20Trackable(_tokenAddress);
         tokenAddress = _tokenAddress;
@@ -264,6 +263,7 @@ contract ScheduledAirDrop {
             // token.airdropFromContractAccount(targetAddress, airdropAmountOfAddress);
         }
 
+        contractInfoStore.addAirdropTokenAddress(tokenAddress, address(this), airdropTargetAddresses);
         token.incrementRoundNumber();  // increment token's airdrop roundNumber.
     }
 

--- a/test/TestAirdrop2.js
+++ b/test/TestAirdrop2.js
@@ -141,9 +141,6 @@ describe("Token & Airdrop contracts test", function() {
         it("Should store the airdropTokenInfo on ContractInfoStore after initiating it", async () => {
             // given
             const {Token, addr1, addr2, addr3, ContractInfoStore} = await loadFixture(deployTokenFixtureNoAirdropContract);
-
-            // when
-            // Airdrop Contract
             const AirdropContract = await ethers.getContractFactory("ScheduledAirDrop");
 
             TOKEN_ADDRESS = Token.address;
@@ -173,6 +170,10 @@ describe("Token & Airdrop contracts test", function() {
                 ContractInfoStoreAddr
             );
 
+            // when
+            // Airdrop Contract
+            await Airdrop.initiateAirdropRound();
+
             // then
             const ContractInfoStoreDetails = await ContractInfoStore.getAllGovernanceTokenInfo();
             const firstContractInfo = ContractInfoStoreDetails[0];
@@ -180,6 +181,9 @@ describe("Token & Airdrop contracts test", function() {
             // airdrop token address is zero and not opened which is false
             expect(firstContractInfo['isAirdropContractOpened']).to.be.true;
             expect(firstContractInfo['airdropTokenAddress']).to.equal(Airdrop.address);
+            expect(firstContractInfo['airdropTargetAddressList']).include(addr1.address);
+            expect(firstContractInfo['airdropTargetAddressList']).include(addr2.address);
+            expect(firstContractInfo['airdropTargetAddressList']).include(addr3.address);
         })
     })
 

--- a/test/TestAirdrop2.js
+++ b/test/TestAirdrop2.js
@@ -33,6 +33,13 @@ describe("Token & Airdrop contracts test", function() {
         // Signers
         const [owner, addr1, addr2, addr3] = await ethers.getSigners();
 
+        // ContractInfoStore contract
+        const ContractInfoStoreFactory = await ethers.getContractFactory("ContractInfoStore");
+
+        const ContractInfoStore = await ContractInfoStoreFactory.deploy();
+
+        const ContractInfoStoreAddr = ContractInfoStore.address;
+
         // Token Contract
         const TokenContract = await ethers.getContractFactory("DAOForceToken");
 
@@ -45,8 +52,10 @@ describe("Token & Airdrop contracts test", function() {
             "some_image_url",
             "some_website_link",
             owner.getAddress(),
-            1500  // DECIMAL == 18
+            1500,  // DECIMAL == 18
+            ContractInfoStoreAddr
         );
+
         await Token.deployed();
 
         // Airdrop Contract

--- a/test/TestAirdrop2.js
+++ b/test/TestAirdrop2.js
@@ -85,10 +85,20 @@ describe("Token & Airdrop contracts test", function() {
             TOTAL_AIRDROP_VOLUME_PER_ROUND
         );
 
-        return { Token, Airdrop, owner, addr1, addr2, addr3 };
+        return { Token, Airdrop, owner, addr1, addr2, addr3, ContractInfoStore };
     }
 
     describe("Token transfer", async function() {
+        it("Should store the tokenInfo on ContractInfoStore rightafter", async () => {
+            const { Token, ContractInfoStore } = await loadFixture(deployTokenFixture);
+            const ContractInfoStoreDetails = await ContractInfoStore.getAllGovernanceTokenInfo();
+            const firstContractInfo = ContractInfoStoreDetails[0];
+
+            expect(firstContractInfo['isAirdropContractOpened']).to.be.false;
+            expect(firstContractInfo['tokenInfo']).to.include('TelescopeToken');
+            expect(firstContractInfo['tokenInfo']['tokenContractAddress']).to.equal(Token.address);
+        })
+
         it("Should transfer ERC20Trackable token between accounts successfully.", async function() {
             const {Token, owner, addr1, addr2, addr3} = await loadFixture(deployTokenFixture);
             


### PR DESCRIPTION
## 구현한 사항
* 거버넌스 토큰의 정보를 저장하는 컨트랙트를 만든다.
* 해당 컨트랙트는 임의의 거버넌스 토큰이 에어드랍 토큰을 추가할 경우 에어드랍 토큰의 정보를 추가한다.
* 사용자의 주소를 입력하면 본인이 claim할 수 있는 거버넌스 토큰과 에어드랍 토큰의 정보를 리턴받을 수 있다.